### PR TITLE
change app theme colors to Gitter brand pink colors

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#2196f3</color>
-    <color name="colorPrimaryDark">#2962ff</color>
-    <color name="colorAccent">#ff4081</color>
+    <color name="colorPrimary">#E20354</color>
+    <color name="colorPrimaryDark">#b70345</color>
+    <color name="colorAccent">#E20354</color>
     <color name="white">#FFFFFF</color>
 </resources>


### PR DESCRIPTION
Fixes #122 

**Changes:**
Change Theme of app

colorPrimary #E20354
colorPrimaryDark #b70345
colorAccent #448AFF

**Screenshots for the change:**

![screenshot-1532396699330](https://user-images.githubusercontent.com/29139786/43112064-d93a3928-8f11-11e8-9037-04307e922106.jpg)