### PR TITLE
Setup Gradle Play Publisher With Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ Screenshots :
 
 <img src="https://user-images.githubusercontent.com/31950172/40463978-efc9de48-5f35-11e8-90c7-6b6f3bb20894.png" width=300><img src="https://user-images.githubusercontent.com/31950172/40463979-f01303b6-5f35-11e8-90a8-2e38f8e41e47.png" width=300>
 
+ ### Automating Publishing to the Play Store
+ 
+    -The first APK or App Bundle needs to be uploaded via the Google Play Console because registering the app with the Play Store cannot be done using the Play Developer API.
+    -To use this plugin, you must create a service account with access to the Play Developer API. Once that's done, you'll need to grant the following permissions to your service account for this plugin to work (go to Settings -> Developer account -> API access -> Service Accounts).
+    -Once done download your PKCS12 key or json key somewhere and the location of key in the build.gradle file in the play block
+    -Then run one of the following commands:
+    | Command | Description |
+   | ------------- | ------------- |
+   | 'publishApkRelease'| Uploads the APK and the summary of recent changes. |
+   | 'publishListingRelease'| Uploads the descriptions and images for the Play Store listing.|
+   | 'publishRelease'| Uploads everything.|
+   | 'bootstrapReleasePlayResources'| Fetch data from the Play Store & bootstrap the required files/folders.|
+                                 
+You can now type the following gradle commands such as the following:
+ bash
+./gradlew publishApkRelease
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,23 @@
+import org.moallemi.gradle.internal.VersionCodeType
+
 apply plugin: 'com.android.application'
 apply plugin: 'realm-android'
+apply plugin: 'com.github.triplet.play'
+apply plugin: 'org.moallemi.advanced-build-version'
+advancedVersioning {
+    nameOptions {
+        versionMajor 2
+        versionMinor 0
+    }
+    codeOptions {
+        versionCodeType VersionCodeType.AUTO_INCREMENT_DATE
+        dependsOnTasks 'release' // defaultValue
+    }
+    outputOptions {
+        renameOutput true
+        nameFormat '${appName}-${buildType}-${versionName}'
+    }
+}
 android {
     compileSdkVersion 27
     buildToolsVersion '27.0.3'
@@ -7,8 +25,9 @@ android {
         applicationId "com.codingblocks.chatter"
         minSdkVersion 15
         targetSdkVersion 27
-        versionCode 11
-        versionName "0.1.1"
+        versionCode advancedVersioning.versionCode
+        versionName advancedVersioning.versionName
+//        versionName "0.1.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
@@ -52,4 +71,9 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation "android.arch.persistence.room:runtime:1.1.1"
     annotationProcessor "android.arch.persistence.room:compiler:1.1.1"
+}
+play {
+    //track can be set to production,alpha or beta
+    jsonFile = file('your-key.json')
+    track = 'beta'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ buildscript {
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+        // For Play Publisher plugin
+        classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
+        // For Android versioning
+        classpath 'org.moallemi.gradle.advanced-build-version:gradle-plugin:1.6.0'
         // I know that but sorry, Realm db docs want you to do so
         classpath "io.realm:realm-gradle-plugin:3.4.0"
     }


### PR DESCRIPTION
Fixes #120

Changes:
Setup for Gradle play Publisher with advance versioning for automating publishing to Play store.
GitHub - Triple-T/gradle-play-publisher:
https://github.com/Triple-T/gradle-play-publisher