### PR TITLE
Change message displayed when no more messages are available in a chat room

### DIFF
--- a/app/src/main/java/com/codingblocks/chatter/fragments/RoomFragment.java
+++ b/app/src/main/java/com/codingblocks/chatter/fragments/RoomFragment.java
@@ -332,7 +332,7 @@ public class RoomFragment extends Fragment {
                             if (getActivity() != null)
                                 Toast.makeText(
                                         getActivity(),
-                                        "There seems to be no rooms, please try again later",
+                                        "There seem to be no more messages",
                                         Toast.LENGTH_SHORT
                                 ).show();
                             Looper.loop();


### PR DESCRIPTION
Fixes #199 

**Changes:**
Changed message displayed when no more messages are available in a chat room. Now the text displayed will be "There seem to be no more messages".
